### PR TITLE
Use the configurable team_model in DocumentTemplate

### DIFF
--- a/src/Models/DocumentTemplate.php
+++ b/src/Models/DocumentTemplate.php
@@ -39,7 +39,7 @@ class DocumentTemplate extends Model
      */
     public function team(): BelongsTo
     {
-        return $this->belongsTo(Team::class, 'team_id');
+        return $this->belongsTo(config('filament-docs.team_model'), 'team_id');
     }
 
 


### PR DESCRIPTION
This is needed to be able to use a custom 'team' model when we set the multi-tenant feature