### PR TITLE
Fix missing CSS asset

### DIFF
--- a/src/FilamentDocsPlugin.php
+++ b/src/FilamentDocsPlugin.php
@@ -4,8 +4,6 @@ namespace TomatoPHP\FilamentDocs;
 
 use Filament\Contracts\Plugin;
 use Filament\Panel;
-use Filament\Support\Assets\Css;
-use Filament\Support\Facades\FilamentAsset;
 use TomatoPHP\FilamentDocs\Filament\RelationManager\DocumentRelationManager;
 use TomatoPHP\FilamentDocs\Filament\Resources\DocumentResource;
 use TomatoPHP\FilamentDocs\Filament\Resources\DocumentTemplateResource;
@@ -39,9 +37,7 @@ class FilamentDocsPlugin implements Plugin
 
     public function boot(Panel $panel): void
     {
-          FilamentAsset::register([
-              Css::make('filament-docs', __DIR__.'/../publish/public/css/filament-docs.css')
-          ]);
+        //
     }
 
     public static function make(): static

--- a/src/FilamentDocsServiceProvider.php
+++ b/src/FilamentDocsServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace TomatoPHP\FilamentDocs;
 
+use Filament\Support\Assets\Css;
+use Filament\Support\Facades\FilamentAsset;
 use Illuminate\Support\ServiceProvider;
 use Livewire\Livewire;
 use TomatoPHP\FilamentDocs\Filament\RelationManager\DocumentRelationManager;
@@ -57,6 +59,8 @@ class FilamentDocsServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
-        //you boot methods here
+        FilamentAsset::register([
+            Css::make('filament-docs', __DIR__.'/../publish/public/css/filament-docs.css')
+        ], package: 'tomatophp/filament-docs');
     }
 }


### PR DESCRIPTION
For the CSS to be picked up by filament:assets command, the FilamentAsset::register call should be in the boot method of the service provider not in the boot method of the Plugin